### PR TITLE
Introducing of 3D histogramming to the Momentum Microscope module

### DIFF
--- a/PESdata_GUI.py
+++ b/PESdata_GUI.py
@@ -415,6 +415,31 @@ class MainApp(App):
                         size_hint=(0.075, 1),
                         halign='center'
                         )
+        # Z step label
+        self.e8 = Label(text='Dim Z step',
+                        font_size=config.kivy_font_size_title,
+                        color=config.kivy_color_white,
+                        font_name=config.kivy_font,
+                        pos_hint={"center_x": 0.5, "center_y": 0.5},
+                        size_hint=(0.275, 1),
+                        halign='center'
+                        )
+        # Z step input
+        self.e9 = TextInput(text='0.1',
+                            multiline=False,
+                            pos_hint={"center_x": 0.5, "center_y": 0.5},
+                            size_hint=(0.15, 0.7),
+                            font_name=config.kivy_font,
+                            font_size=config.kivy_font_size
+                            )
+        self.e10 = Label(text='a.u.',
+                         font_size=config.kivy_font_size_title,
+                         color=config.kivy_color_white,
+                         font_name=config.kivy_font,
+                         pos_hint={"center_x": 0.5, "center_y": 0.5},
+                         size_hint=(0.075, 1),
+                         halign='center'
+                         )
 
         # add widgets to the line
         self.box5.add_widget(self.e1)
@@ -424,6 +449,16 @@ class MainApp(App):
         self.box5.add_widget(self.e5)
         self.box5.add_widget(self.e6)
         self.box5.add_widget(self.e7)
+        if config.file_type == 'MM':
+            self.box5.add_widget(self.e8)
+            self.box5.add_widget(self.e9)
+            self.box5.add_widget(self.e10)
+            for i in [2, 5, 8]:
+                getattr(self, f'e{i}').size_hint = (0.1833, 1)
+            for i in [3, 6, 9]:
+                getattr(self, f'e{i}').size_hint = (0.1, 0.7)
+            for i in [4, 7, 10]:
+                getattr(self, f'e{i}').size_hint = (0.05, 1)
         '''
         BUNCH FILTERING
         '''
@@ -696,8 +731,12 @@ class MainApp(App):
                     halign='center'
                     )
         # Total electrons norm
+        if config.file_type in ['MM']:
+            t_e_n_state = 'normal'
+        else:
+            t_e_n_state = 'down'
         self.j2 = ToggleButton(text='Total electrons: ON',
-                               state='down',
+                               state=t_e_n_state,
                                font_name=config.kivy_font,
                                font_size=config.kivy_font_size,
                                pos_hint={"center_x": 0.5, "center_y": 0.5},
@@ -1326,6 +1365,17 @@ class MainApp(App):
                         self.box2.add_widget(self.run_numbers_label)
                         self.run_numbers_input.size_hint = (1, 0.8)
                         self.box2.add_widget(self.run_numbers_input)
+                        
+                        self.box5.clear_widgets()
+                        self.e1.size_hint = (0.5, 1)
+                        for i in [2, 5]:
+                            getattr(self, f'e{i}').size_hint = (0.275, 1)
+                        for i in [3, 6]:
+                            getattr(self, f'e{i}').size_hint = (0.15, 0.7)
+                        for i in [4, 7]:
+                            getattr(self, f'e{i}').size_hint = (0.075, 1)
+                        for i in range(1,8):
+                            self.box5.add_widget(getattr(self, f'e{i}'))
 
                         self.box7.clear_widgets()
                         self.box7.add_widget(self.create_map)
@@ -1379,6 +1429,17 @@ class MainApp(App):
                         self.box2.add_widget(self.run_numbers_label)
                         self.run_numbers_input.size_hint = (1, 0.8)
                         self.box2.add_widget(self.run_numbers_input)
+                        
+                        self.box5.clear_widgets()
+                        self.e1.size_hint = (0.5, 1)
+                        for i in [2, 5, 8]:
+                            getattr(self, f'e{i}').size_hint = (0.1833, 1)
+                        for i in [3, 6, 9]:
+                            getattr(self, f'e{i}').size_hint = (0.1, 0.7)
+                        for i in [4, 7, 10]:
+                            getattr(self, f'e{i}').size_hint = (0.05, 1)
+                        for i in range(1, 11):
+                            self.box5.add_widget(getattr(self, f'e{i}'))
 
                         self.box7.clear_widgets()
                         self.box7.add_widget(self.create_map)
@@ -1435,6 +1496,17 @@ class MainApp(App):
                         self.run_numbers_input.size_hint = (0.8, 0.8)
                         self.box2.add_widget(self.run_numbers_input)
                         self.box2.add_widget(self.DLD_toggle)
+
+                        self.box5.clear_widgets()
+                        self.e1.size_hint = (0.5, 1)
+                        for i in [2, 5]:
+                            getattr(self, f'e{i}').size_hint = (0.275, 1)
+                        for i in [3, 6]:
+                            getattr(self, f'e{i}').size_hint = (0.15, 0.7)
+                        for i in [4, 7]:
+                            getattr(self, f'e{i}').size_hint = (0.075, 1)
+                        for i in range(1,8):
+                            self.box5.add_widget(getattr(self, f'e{i}'))
 
                         self.box7.clear_widgets()
                         self.box7.add_widget(self.create_map)
@@ -1533,9 +1605,18 @@ class MainApp(App):
 
             if self.f5.state == 'down':
                 for i in self.batch.batch_list:
-                    B_range = self.f6.text.split(',')
-                    B_range = [float(i) for i in B_range]
-                    i.Bunch_filter(B_range, B_type='MicroBunch')
+                    if config.file_type == 'MM':
+                        dims = self.f6.text.split(';')
+                        for j in dims:
+                            i_vals = j.split(',')
+                            B_type = i_vals[0]
+                            B_range = i_vals[1:]
+                            B_range = [float(k) for k in B_range]
+                            i.Bunch_filter(B_range, B_type=B_type)
+                    else:
+                        B_range = self.f6.text.split(',')
+                        B_range = [float(i) for i in B_range]
+                        i.Bunch_filter(B_range, B_type='MicroBunch')
 
             # Input for WESPE
             try:
@@ -1566,15 +1647,19 @@ class MainApp(App):
                 ordinate = self.hist_mode.text
 
             for i in self.batch.batch_list:
-                try:
+                if config.file_type == 'MM':
+                    z_step = float(self.e9.text)
+                    i.create_map(energy_step, delay_step, z_step,
+                                 ordinate=ordinate,
+                                 save=config.save_nc)
+                elif config.file_type == 'WESPE':
                     i.create_map(energy_step, delay_step, ordinate=ordinate,
                                  save=config.save_nc)
-                except:
-                    try:
-                        i.create_map(ordinate=ordinate, bunch_sel=bunch_sel,
-                                     DLD_t_res=DLD_t_res, save=config.save_nc)
-                    except:
-                        i.create_map()
+                elif config.file_type == 'ALS':
+                    i.create_map(ordinate=ordinate, bunch_sel=bunch_sel,
+                                 DLD_t_res=DLD_t_res, save=config.save_nc)
+                else:
+                    i.create_map()
                 if self.d5.state == 'down':
                     i.set_BE()
 
@@ -2827,6 +2912,17 @@ class MainApp(App):
             self.run_numbers_input.size_hint = (0.8, 0.8)
             self.box2.add_widget(self.run_numbers_input)
             self.box2.add_widget(self.DLD_toggle)
+            
+            self.box5.clear_widgets()
+            self.e1.size_hint = (0.5, 1)
+            for i in [2, 5]:
+                getattr(self, f'e{i}').size_hint = (0.275, 1)
+            for i in [3, 6]:
+                getattr(self, f'e{i}').size_hint = (0.15, 0.7)
+            for i in [4, 7]:
+                getattr(self, f'e{i}').size_hint = (0.075, 1)
+            for i in range(1,8):
+                self.box5.add_widget(getattr(self, f'e{i}'))
 
             self.box7.clear_widgets()
             self.box7.add_widget(self.create_map)
@@ -2841,6 +2937,17 @@ class MainApp(App):
             self.box2.add_widget(self.run_numbers_label)
             self.run_numbers_input.size_hint = (1, 0.8)
             self.box2.add_widget(self.run_numbers_input)
+            
+            self.box5.clear_widgets()
+            self.e1.size_hint = (0.5, 1)
+            for i in [2, 5]:
+                getattr(self, f'e{i}').size_hint = (0.275, 1)
+            for i in [3, 6]:
+                getattr(self, f'e{i}').size_hint = (0.15, 0.7)
+            for i in [4, 7]:
+                getattr(self, f'e{i}').size_hint = (0.075, 1)
+            for i in range(1,8):
+                self.box5.add_widget(getattr(self, f'e{i}'))
 
             self.box7.clear_widgets()
             self.box7.add_widget(self.create_map)
@@ -2855,6 +2962,17 @@ class MainApp(App):
             self.box2.add_widget(self.run_numbers_label)
             self.run_numbers_input.size_hint = (1, 0.8)
             self.box2.add_widget(self.run_numbers_input)
+
+            self.box5.clear_widgets()
+            self.e1.size_hint = (0.5, 1)
+            for i in [2, 5, 8]:
+                getattr(self, f'e{i}').size_hint = (0.1833, 1)
+            for i in [3, 6, 9]:
+                getattr(self, f'e{i}').size_hint = (0.1, 0.7)
+            for i in [4, 7, 10]:
+                getattr(self, f'e{i}').size_hint = (0.05, 1)
+            for i in range(1, 11):
+                self.box5.add_widget(getattr(self, f'e{i}'))
 
             self.box7.clear_widgets()
             self.box7.add_widget(self.create_map)

--- a/PESdata_GUI.py
+++ b/PESdata_GUI.py
@@ -1761,8 +1761,9 @@ class MainApp(App):
                 self.batch.set_BE()
 
             if self.h3.state == 'down':
-                self.batch.create_dif_map()
-                self.batch.set_dif_map()
+                if self.batch.Map_2D.ndim < 3:
+                    self.batch.create_dif_map()
+                    self.batch.set_dif_map()
 
             if self.j3.state == 'down':
                 self.batch.norm_01()
@@ -1790,10 +1791,16 @@ class MainApp(App):
                     ROI_D = [np.min(ROI_D), np.max(ROI_D)]
                     print(ROI_D)
                 self.batch.ROI(ROI_D, 'Dim_y')
-
-            plot_files(self.batch, dpi=self.dpi,
-                       fig_width=self.fig_width,
-                       fig_height=self.fig_height)
+                
+            if self.h3.state == 'down' and self.batch.Map_2D.ndim > 2:
+                plot_files(self.batch, dpi=self.dpi,
+                           fig_width=self.fig_width,
+                           fig_height=self.fig_height,
+                           dif_3D=True)
+            else:
+                plot_files(self.batch, dpi=self.dpi,
+                           fig_width=self.fig_width,
+                           fig_height=self.fig_height)
 
             if self.create_plot_mode.state == 'down':
                 path = self.directory_input.text.strip() + os.sep

--- a/packages/PESdata_OOP.py
+++ b/packages/PESdata_OOP.py
@@ -2514,6 +2514,10 @@ class read_file_MM(create_batch_WESPE):
             except:
                 use_julia = False
                 print('***All-Python mode***')
+
+            if self.switch_3D is True and use_julia is False:
+                raise Exception('***For 3D histogramming, please set up Julia-enabled mode***')
+
             start = timer()
             '''
             This part is supposed to filter artifact values
@@ -5337,8 +5341,8 @@ if __name__ == "__main__":
         # i.Bunch_filter([0.4,0.9], B_type='x')
         # i.Bunch_filter([0.4,0.9], B_type='y')
         # i.Bunch_filter([4,4.27], B_type='t')
-        i.create_map(ordinate='xy', energy_step=0.001, delay_step=0.001, z_step=0.1,
-                     save='on')
+        i.create_map(ordinate='xyt', energy_step=0.001, delay_step=0.001, z_step=100,
+                     save='off')
     b.create_map()
     # b.time_zero(t0=3539.7)
     # b.save_map_dat()

--- a/packages/PESdata_OOP.py
+++ b/packages/PESdata_OOP.py
@@ -717,14 +717,17 @@ class create_batch_WESPE:
                 if self.map_y_tick == 0:
                     self.map_y_tick = 1
             else:
-                for option in [1, 0.5, 0.2, 0.1, 0.05, 0.01]:
+                for option in [1, 0.5, 0.2, 0.1, 0.05, 0.01, 0.001, 0.0001]:
                     if self.rounding(self.map_y_tick, option) > 0:
                         self.map_y_tick = self.rounding(self.map_y_tick,
                                                         option)
                         self.map_y_tick_decimal = self.decimal_n(option)
+                        self.map_y_tick = round(self.map_y_tick,
+                                                self.map_y_tick_decimal)
                         break
-                self.map_y_tick = round(self.map_y_tick,
-                                        self.map_y_tick_decimal)
+                    else:
+                        if option == 0.0001:
+                            self.map_y_tick = 0.0001
 
             self.map_x_max = np.nanmax(image_data_x)
             self.map_x_min = np.nanmin(image_data_x)
@@ -734,14 +737,17 @@ class create_batch_WESPE:
                 if self.map_x_tick == 0:
                     self.map_x_tick = 1
             else:
-                for option in [1, 0.5, 0.2, 0.1, 0.05, 0.01]:
+                for option in [1, 0.5, 0.2, 0.1, 0.05, 0.01, 0.001, 0.0001]:
                     if self.rounding(self.map_x_tick, option) > 0:
                         self.map_x_tick = self.rounding(self.map_x_tick,
                                                         option)
                         self.map_x_tick_decimal = self.decimal_n(option)
+                        self.map_x_tick = round(self.map_x_tick,
+                                                self.map_x_tick_decimal)
                         break
-                self.map_x_tick = round(self.map_x_tick,
-                                        self.map_x_tick_decimal)
+                    else:
+                        if option == 0.0001:
+                            self.map_x_tick = 0.0001
 
             if self.Map_2D_plot.attrs[order_x] is False:
                 x_start = np.min(image_data_x)
@@ -4684,7 +4690,7 @@ class map_cut:
         self.cuts = cuts
         self.arb_u = True
 
-    def axs_plot(self, axs):
+    def axs_plot(self, axs, dif_3D=False):
         '''
         Method for creating matplotlib axes for map_cut slices.
         '''
@@ -4719,9 +4725,12 @@ class map_cut:
                     self.cut_y_tick = read_file_WESPE.rounding(self.cut_y_tick,
                                                                option)
                     self.cut_y_tick_decimal = read_file_WESPE.decimal_n(option)
+                    self.cut_y_tick = round(self.cut_y_tick,
+                                            self.cut_y_tick_decimal)
                     break
-            self.cut_y_tick = round(self.cut_y_tick,
-                                    self.cut_y_tick_decimal)
+                else:
+                    if option == 0.0001:
+                        self.cut_y_tick = 0.0001
 
         self.cut_x_max = np.nanmax(self.coords)
         self.cut_x_min = np.nanmin(self.coords)
@@ -4732,14 +4741,17 @@ class map_cut:
             if self.cut_x_tick == 0:
                 self.cut_x_tick = 1
         else:
-            for option in [1, 0.5, 0.2, 0.1, 0.05, 0.01]:
+            for option in [1, 0.5, 0.2, 0.1, 0.05, 0.01, 0.001, 0.0001]:
                 if read_file_WESPE.rounding(self.cut_x_tick, option) > 0:
                     self.cut_x_tick = read_file_WESPE.rounding(self.cut_x_tick,
                                                                option)
                     self.cut_x_tick_decimal = read_file_WESPE.decimal_n(option)
+                    self.cut_x_tick = round(self.cut_x_tick,
+                                            self.cut_x_tick_decimal)
                     break
-            self.cut_x_tick = round(self.cut_x_tick,
-                                    self.cut_x_tick_decimal)
+                else:
+                    if option == 0.0001:
+                        self.cut_x_tick = 0.0001
 
         if self.cut_info.attrs['x_alt'] is True:
             x_label = self.cut_info.attrs['x_label_a']
@@ -5147,7 +5159,7 @@ if __name__ == "__main__":
         i.Bunch_filter([0.4,0.9], B_type='x')
         i.Bunch_filter([0.4,0.9], B_type='y')
         i.Bunch_filter([4,4.27], B_type='t')
-        i.create_map(ordinate='xyd', energy_step=0.005, delay_step=0.005, z_step=0.1,
+        i.create_map(ordinate='td', energy_step=0.005, delay_step=0.005, z_step=0.1,
                      save='on')
     b.create_map()
     # b.save_map_dat()

--- a/packages/PESdata_OOP.py
+++ b/packages/PESdata_OOP.py
@@ -286,12 +286,24 @@ class create_batch_WESPE:
         Method for creating new array coordinate 'Delay relative t0'
         after specification of the delay stage value considered as time zero.
         '''
-        self.t0 = read_file_WESPE.rounding(t0, self.y_step)
-        y_label_a = self.Map_2D_plot.attrs['y_label_a']
-        y_label = self.Map_2D_plot.attrs['y_label']
-        image_data_y_a = self.t0 - self.Map_2D.coords[y_label].values
-        self.Map_2D.coords[y_label_a] = ('Dim_y', image_data_y_a)
-        self.Map_2D_plot.coords[y_label_a] = ('Dim_y', image_data_y_a)
+        check = []
+        for i in ['x', 'y', 'z']:
+            try:
+                if self.Map_2D_plot.attrs[f'{i}_units'] == 'ps':
+                    check.append(i)
+            except:
+                pass
+        try:
+            check = check[0]
+            self.t0 = read_file_WESPE.rounding(t0, getattr(self, f'{check}_step'))
+            label_a = self.Map_2D_plot.attrs[f'{check}_label_a']
+            label = self.Map_2D_plot.attrs[f'{check}_label']
+            image_data_a = self.t0 - self.Map_2D.coords[label].values
+            self.Map_2D.coords[label_a] = (f'Dim_{check}', image_data_a)
+            self.Map_2D_plot.coords[label_a] = (f'Dim_{check}', image_data_a)
+            self.set_T0()
+        except:
+            pass
         self.set_T0()
 
     def create_map(self):
@@ -397,20 +409,42 @@ class create_batch_WESPE:
         Method for switching visualization to 'Delay relative t0'
         coordinate of 'Dim_y' dimension.
         '''
-        if self.Map_2D_plot.attrs['y_alt'] is False:
-            coord = self.Map_2D_plot.coords[self.Map_2D_plot.attrs['y_label_a']]
-            self.Map_2D_plot.coords['Dim_y'] = coord
-            self.Map_2D_plot.attrs['y_alt'] = True
-
+        check = []
+        for i in ['x', 'y', 'z']:
+            try:
+                if self.Map_2D_plot.attrs[f'{i}_units'] == 'ps':
+                    check.append(i)
+            except:
+                pass
+        try:
+            check = check[0]
+            if self.Map_2D_plot.attrs[f'{check}_alt'] is False:
+                coord = self.Map_2D_plot.coords[self.Map_2D_plot.attrs[f'{check}_label_a']]
+                self.Map_2D_plot.coords[f'Dim_{check}'] = coord
+                self.Map_2D_plot.attrs[f'{check}_alt'] = True
+        except:
+            pass
+            
     def set_Tds(self):
         '''
         Method for switching visualization to 'Delay stage values'
         coordinate of 'Dim_y' dimension.
         '''
-        if self.Map_2D_plot.attrs['y_alt'] is True:
-            coord = self.Map_2D_plot.coords[self.Map_2D_plot.attrs['y_label']]
-            self.Map_2D_plot.coords['Dim_y'] = coord
-            self.Map_2D_plot.attrs['y_alt'] = False
+        check = []
+        for i in ['x', 'y', 'z']:
+            try:
+                if self.Map_2D_plot.attrs[f'{i}_units'] == 'ps':
+                    check.append(i)
+            except:
+                pass
+        try:
+            check = check[0]
+            if self.Map_2D_plot.attrs[f'{check}_alt'] is True:
+                coord = self.Map_2D_plot.coords[self.Map_2D_plot.attrs[f'{check}_label']]
+                self.Map_2D_plot.coords[f'Dim_{check}'] = coord
+                self.Map_2D_plot.attrs[f'{check}_alt'] = False
+        except:
+            pass
 
     def set_dif_map(self):
         '''
@@ -1605,13 +1639,66 @@ class read_file_WESPE:
         Method for creating new array coordinate 'Delay relative t0'
         after specification of the delay stage value considered as time zero.
         '''
-        self.t0 = read_file_WESPE.rounding(t0, self.y_step)
-        y_label_a = self.Map_2D_plot.attrs['y_label_a']
-        y_label = self.Map_2D_plot.attrs['y_label']
-        image_data_y_a = self.t0 - self.Map_2D.coords[y_label].values
-        self.Map_2D.coords[y_label_a] = ('Dim_y', image_data_y_a)
-        self.Map_2D_plot.coords[y_label_a] = ('Dim_y', image_data_y_a)
-        self.set_T0()
+        check = []
+        for i in ['x', 'y', 'z']:
+            try:
+                if self.Map_2D_plot.attrs[f'{i}_units'] == 'ps':
+                    check.append(i)
+            except:
+                pass
+        try:
+            check = check[0]
+            self.t0 = read_file_WESPE.rounding(t0, getattr(self, f'{check}_step'))
+            label_a = self.Map_2D_plot.attrs[f'{check}_label_a']
+            label = self.Map_2D_plot.attrs[f'{check}_label']
+            image_data_a = self.t0 - self.Map_2D.coords[label].values
+            self.Map_2D.coords[label_a] = (f'Dim_{check}', image_data_a)
+            self.Map_2D_plot.coords[label_a] = (f'Dim_{check}', image_data_a)
+            self.set_T0()
+        except:
+            pass
+
+    def set_T0(self):
+        '''
+        Method for switching visualization to 'Delay relative t0'
+        coordinate of 'Dim_y' dimension.
+        '''
+        check = []
+        for i in ['x', 'y', 'z']:
+            try:
+                if self.Map_2D_plot.attrs[f'{i}_units'] == 'ps':
+                    check.append(i)
+            except:
+                pass
+        try:
+            check = check[0]
+            if self.Map_2D_plot.attrs[f'{check}_alt'] is False:
+                coord = self.Map_2D_plot.coords[self.Map_2D_plot.attrs[f'{check}_label_a']]
+                self.Map_2D_plot.coords[f'Dim_{check}'] = coord
+                self.Map_2D_plot.attrs[f'{check}_alt'] = True
+        except:
+            pass
+
+    def set_Tds(self):
+        '''
+        Method for switching visualization to 'Delay stage values'
+        coordinate of 'Dim_y' dimension.
+        '''
+        check = []
+        for i in ['x', 'y', 'z']:
+            try:
+                if self.Map_2D_plot.attrs[f'{i}_units'] == 'ps':
+                    check.append(i)
+            except:
+                pass
+        try:
+            check = check[0]
+            if self.Map_2D_plot.attrs[f'{check}_alt'] is True:
+                coord = self.Map_2D_plot.coords[self.Map_2D_plot.attrs[f'{check}_label']]
+                self.Map_2D_plot.coords[f'Dim_{check}'] = coord
+                self.Map_2D_plot.attrs[f'{check}_alt'] = False
+        except:
+            pass
 
     def create_dif_map(self):
         '''
@@ -1879,72 +1966,6 @@ class create_batch_MM(create_batch_WESPE):
         self.static_cut_list = static_cut_list
         short_info = [title, run_num, is_static_s, KE_s, mono_s]
         self.short_info = '\n'.join(short_info) + '\n\n'
-
-    def time_zero(self, t0=1328.2):
-        '''
-        Method for creating new array coordinate 'Delay relative t0'
-        after specification of the delay stage value considered as time zero.
-        '''
-        check = []
-        for i in ['x', 'y', 'z']:
-            try:
-                if self.Map_2D_plot.attrs[f'{i}_units'] == 'ps':
-                    check.append(i)
-            except:
-                pass
-        try:
-            check = check[0]
-            self.t0 = read_file_WESPE.rounding(t0, getattr(self, f'{check}_step'))
-            label_a = self.Map_2D_plot.attrs[f'{check}_label_a']
-            label = self.Map_2D_plot.attrs[f'{check}_label']
-            image_data_a = self.t0 - self.Map_2D.coords[label].values
-            self.Map_2D.coords[label_a] = (f'Dim_{check}', image_data_a)
-            self.Map_2D_plot.coords[label_a] = (f'Dim_{check}', image_data_a)
-            self.set_T0()
-        except:
-            pass
-        
-    def set_T0(self):
-        '''
-        Method for switching visualization to 'Delay relative t0'
-        coordinate of 'Dim_y' dimension.
-        '''
-        check = []
-        for i in ['x', 'y', 'z']:
-            try:
-                if self.Map_2D_plot.attrs[f'{i}_units'] == 'ps':
-                    check.append(i)
-            except:
-                pass
-        try:
-            check = check[0]
-            if self.Map_2D_plot.attrs[f'{check}_alt'] is False:
-                coord = self.Map_2D_plot.coords[self.Map_2D_plot.attrs[f'{check}_label_a']]
-                self.Map_2D_plot.coords[f'Dim_{check}'] = coord
-                self.Map_2D_plot.attrs[f'{check}_alt'] = True
-        except:
-            pass
-            
-    def set_Tds(self):
-        '''
-        Method for switching visualization to 'Delay stage values'
-        coordinate of 'Dim_y' dimension.
-        '''
-        check = []
-        for i in ['x', 'y', 'z']:
-            try:
-                if self.Map_2D_plot.attrs[f'{i}_units'] == 'ps':
-                    check.append(i)
-            except:
-                pass
-        try:
-            check = check[0]
-            if self.Map_2D_plot.attrs[f'{check}_alt'] is True:
-                coord = self.Map_2D_plot.coords[self.Map_2D_plot.attrs[f'{check}_label']]
-                self.Map_2D_plot.coords[f'Dim_{check}'] = coord
-                self.Map_2D_plot.attrs[f'{check}_alt'] = False
-        except:
-            pass
 
     def set_KE(self):
         '''
@@ -2742,19 +2763,6 @@ class read_file_MM(create_batch_WESPE):
             end = timer()
             print(f'Run {self.run_num} done')
             print(f'Elapsed time: {round(end-start, 1)} s')
-
-    def time_zero(self, t0=1328.2):
-        '''
-        Method for creating new array coordinate 'Delay relative t0'
-        after specification of the delay stage value considered as time zero.
-        '''
-        self.t0 = read_file_WESPE.rounding(t0, self.y_step)
-        y_label_a = self.Map_2D_plot.attrs['y_label_a']
-        y_label = self.Map_2D_plot.attrs['y_label']
-        image_data_y_a = self.t0 - self.Map_2D.coords[y_label].values
-        self.Map_2D.coords[y_label_a] = ('Dim_y', image_data_y_a)
-        self.Map_2D_plot.coords[y_label_a] = ('Dim_y', image_data_y_a)
-        self.set_T0()
 
     def create_dif_map(self):
         '''


### PR DESCRIPTION
1) **3D histogramming** was added; the 'Dim Z step' field defines the step size for the z-axis. It is activated when the 'Select dims' field gets three key letters instead of two.
2) The **MicroB filter** field turned into a custom filter (will be renamed in further updates). One can filter five dimensions by specifying: 'keyletter, lim1,lim2' (separated with comma). Semicolon separates different requests for filtering.
3) A difference plot of 2D slices for the 3D view was added.
4) Energy/Time dimensions became disentangled from X/Y axes.